### PR TITLE
fix(yabai): skip --display if space is already on target display

### DIFF
--- a/home/dot_config/fish/functions/core/yabai/yabai.space_create.fish
+++ b/home/dot_config/fish/functions/core/yabai/yabai.space_create.fish
@@ -4,13 +4,19 @@ function yabai.space_create
     set -l name $argv[3]
     # $argv[4] is "--" separator
     set -l apps $argv[5..-1]
-    set -l space (yabai -m query --spaces | jq "first(.[] | select(.index == $idx) | .index)")
+    set -l spaces_json (yabai -m query --spaces)
+    set -l space (echo $spaces_json | jq "first(.[] | select(.index == $idx) | .index)")
+    set -l current_display (echo $spaces_json | jq "first(.[] | select(.index == $idx) | .display)")
 
     if test -z "$space"
         yabai -m space --create
     end
 
-    yabai -m space "$idx" --label "$name" --display "$display"
+    yabai -m space "$idx" --label "$name"
+
+    if test "$current_display" != "$display"
+        yabai -m space "$idx" --display "$display"
+    end
 
     if test (count $apps) -gt 0
         set -l pattern "^("(string join "|" $apps)")\$"


### PR DESCRIPTION
## Summary

- Fixes repeated warning `acting space is already located on the given display` on yabai startup
- `yabai.space_create` now queries the current display of each space before issuing `--display`, and skips the move if the space is already on the correct display
- Caches `yabai -m query --spaces` output to avoid an extra CLI call

## Test plan

- [ ] Run `chezmoi apply && yabai --restart-service`
- [ ] Verify the warning no longer appears in the yabai output